### PR TITLE
Using a different variable now. Running the validator without passing…

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function gulpAccessibility(options) {
   if (gulpOptions.urls) {
     return accessSniff.start(gulpOptions.urls, gulpOptions, function(messageLog, err) {
 
-      if (options.force) {
+      if (gulpOptions.force) {
         err = 0;
       }
 
@@ -48,7 +48,7 @@ function gulpAccessibility(options) {
     if (file.isBuffer()) {
       accessSniff.start(files, gulpOptions, function(messageLog, err) {
 
-        if (options.force) {
+        if (gulpOptions.force) {
           err = 0;
         }
 


### PR DESCRIPTION
… any options was causing an error: 'TypeError: Cannot read property 'force' of undefined'.
