### PR TITLE
return node error when there is at least one error for accessibility …

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,12 @@ function gulpAccessibility(options) {
           err = 0;
         }
 
-        return cb(null, messageLog);
+        var error = null;
+        if (err > 0) {
+          error = new Error('at least ' + err + ' errors found when check accessibility')
+        }
+
+        return cb(error, messageLog);
       });
     }
 


### PR DESCRIPTION
return node error when there is at least one error for accessibility check. #7 
